### PR TITLE
Added block names to BlockLogger output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 .gradle/
 build/
-server/
 .idea/
-src.bak/
 canyon-api/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A custom-written plugin for [canyon, a craftbukkit fork for minecraft beta 1.7.3
 
 ## Features
 - a `/players` / `/list` command for non-op players.
-- a block logger (inspection available for op players under `/blocklog`) <- **INCOMPLETE! Some block-altering actions like pistons, explosions, snow appearing in snowy biomes or mushrooms growing and stealing from chests are not handled yet!**
+- a block logger (inspection available for op players under `/blocklog`) <- **INCOMPLETE! Some block-altering actions like pistons, explosions, snow appearing in snowy biomes or mushrooms growing aren't handled yet!**
 - a configurable `/info`/`/rules` command.
 - configurable "hello" and "btw" messages.
 - `/myplugin-reload` for reloading the config while the server is running.
@@ -11,13 +11,17 @@ A custom-written plugin for [canyon, a craftbukkit fork for minecraft beta 1.7.3
 
 ## Downloads are available under the [releases tab](https://github.com/Blayung/my-plugin/releases)!
 
-## Complete documentation
+## Documentation
 ### The block logger
+It will log blocks being placed or destroyed and items being stolen from or put into containers.  
+  
 The command's name is `blocklog`, and it uses the following aliases: `blocklogger`, `inspect`.  
   
 When used without arguments, it will toggle the inspection status of the player who ran it, and if at least a single argument is provided, the player specified in the first argument will get he's inspection status toggled instead.  
   
-When the inspection status is turned on, you can left-click blocks to check their history, or right-click them to see the history of the block next to them (on the block face you clicked at). You won't be able to destroy or place blocks, and interact with e.g. doors or trapdoors.  
+When the inspection status is turned on, you can left-click blocks to check their history, or right-click them to see the history of the block next to them (on the block face you clicked at). You won't be able to destroy or place blocks, or interact with e.g. doors or trapdoors.  
+  
+When checking double-chests for items being stolen or put in, make sure that you check both blocks since the plugin will save the interactions at only one.  
   
 The block log history will be saved in `plugins/MyPlugin/block-log-book.txt` when the world saves.
 

--- a/src/main/java/com/blay/myplugin/BlockLogger.java
+++ b/src/main/java/com/blay/myplugin/BlockLogger.java
@@ -147,7 +147,7 @@ public class BlockLogger {
             Location location = event.getContainerLocation();
             ItemStack itemStack = event.getItemStack();
             MaterialData itemMaterialData = itemStack.getData();
-            logBook.add(new LogBookEntry(event.isStolen() ? LogBookEntryType.STOLEN : LogBookEntryType.PUT, Instant.now().getEpochSecond(), event.getPlayer().getName(), location.getWorld().getName(), (int)location.getX(), (int)location.getY(), (int)location.getZ(), itemStack.getTypeId(), itemMaterialData == null ? 0 : itemMaterialData.getData(), itemStack.getAmount()));
+            logBook.add(new LogBookEntry(event.isStolen() ? LogBookEntryType.STOLEN : LogBookEntryType.PUT, Instant.now().getEpochSecond(), event.getPlayer().getName(), location.getWorld().getName(), (int) location.getX(), (int) location.getY(), (int) location.getZ(), itemStack.getTypeId(), itemMaterialData == null ? 0 : itemMaterialData.getData(), itemStack.getAmount()));
         }
     }
 

--- a/src/main/java/com/blay/myplugin/BlockLogger.java
+++ b/src/main/java/com/blay/myplugin/BlockLogger.java
@@ -144,10 +144,10 @@ public class BlockLogger {
 
     public static class TransactionListener extends InventoryListener {
         public void onTransaction(TransactionEvent event) {
-            Player player = event.getPlayer();
+            Location location = event.getContainerLocation();
             ItemStack itemStack = event.getItemStack();
             MaterialData itemMaterialData = itemStack.getData();
-            logBook.add(new LogBookEntry(event.isStolen() ? LogBookEntryType.STOLEN : LogBookEntryType.PUT, Instant.now().getEpochSecond(), player.getName(), player.getWorld().getName(), event.getX(), event.getY(), event.getZ(), itemStack.getTypeId(), itemMaterialData == null ? 0 : itemMaterialData.getData(), itemStack.getAmount()));
+            logBook.add(new LogBookEntry(event.isStolen() ? LogBookEntryType.STOLEN : LogBookEntryType.PUT, Instant.now().getEpochSecond(), event.getPlayer().getName(), location.getWorld().getName(), (int)location.getX(), (int)location.getY(), (int)location.getZ(), itemStack.getTypeId(), itemMaterialData == null ? 0 : itemMaterialData.getData(), itemStack.getAmount()));
         }
     }
 

--- a/src/main/java/com/blay/myplugin/MyPlugin.java
+++ b/src/main/java/com/blay/myplugin/MyPlugin.java
@@ -20,6 +20,14 @@ import java.io.FileWriter;
 import java.util.ArrayList;
 
 public class MyPlugin extends JavaPlugin {
+    private static Server server;
+    private static final Random random = new Random();
+
+    private String[] infoLines;
+    private static String[] onJoinMessages;
+    private static String[] btwMessages;
+    private int btwMessagesTaskId = -1;
+
     public static class OnPlayerJoinListener extends PlayerListener {
         public void onPlayerJoin(PlayerJoinEvent event) {
             Player player = event.getPlayer();
@@ -39,14 +47,6 @@ public class MyPlugin extends JavaPlugin {
             }
         }
     }
-
-    private static Server server;
-    private static final Random random = new Random();
-
-    private String[] infoLines;
-    private static String[] onJoinMessages;
-    private static String[] btwMessages;
-    private int btwMessagesTaskId = -1;
 
     private void reloadConfig() {
         File pluginFolder = new File("./plugins/MyPlugin");
@@ -102,16 +102,16 @@ public class MyPlugin extends JavaPlugin {
 
         reloadConfig();
 
-        BlockLogger blockLogger = new BlockLogger();
-
         PluginManager pluginManager = server.getPluginManager();
 
-        pluginManager.registerEvent(Event.Type.BLOCK_BREAK, blockLogger, Event.Priority.Normal, this);
-        pluginManager.registerEvent(Event.Type.BLOCK_BURN, blockLogger, Event.Priority.Normal, this);
-        pluginManager.registerEvent(Event.Type.BLOCK_FADE, blockLogger, Event.Priority.Normal, this);
-        pluginManager.registerEvent(Event.Type.LEAVES_DECAY, blockLogger, Event.Priority.Normal, this);
-        pluginManager.registerEvent(Event.Type.BLOCK_PLACE, blockLogger, Event.Priority.Normal, this);
+        BlockLogger.BlockEventListener blockEventListener = new BlockLogger.BlockEventListener();
+        pluginManager.registerEvent(Event.Type.BLOCK_BREAK, blockEventListener, Event.Priority.Normal, this);
+        pluginManager.registerEvent(Event.Type.BLOCK_BURN, blockEventListener, Event.Priority.Normal, this);
+        pluginManager.registerEvent(Event.Type.BLOCK_FADE, blockEventListener, Event.Priority.Normal, this);
+        pluginManager.registerEvent(Event.Type.LEAVES_DECAY, blockEventListener, Event.Priority.Normal, this);
+        pluginManager.registerEvent(Event.Type.BLOCK_PLACE, blockEventListener, Event.Priority.Normal, this);
 
+        pluginManager.registerEvent(Event.Type.INVENTORY_TRANSACTION, new BlockLogger.TransactionListener(), Event.Priority.Normal, this);
         pluginManager.registerEvent(Event.Type.PLAYER_INTERACT, new BlockLogger.OnPlayerInteractListener(), Event.Priority.Normal, this);
         pluginManager.registerEvent(Event.Type.WORLD_SAVE, new BlockLogger.OnWorldSaveListener(), Event.Priority.Normal, this);
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: MyPlugin
-version: 1.0.3
+version: 1.1.0
 description: Doing various things on the server.
 author: Blay
 


### PR DESCRIPTION
Decided to write some addition to the source so that Block Log would also display block name next to the block ID (like the standard /give command does in this version).
Now it outputs this:
![image](https://github.com/Blayung/my-plugin/assets/101307532/a3cf7078-0ac9-4cae-8a38-2bacade712b7)
